### PR TITLE
feat(#17): implement mnto --clean and --prune commands

### DIFF
--- a/lib/blackboard.bash
+++ b/lib/blackboard.bash
@@ -318,3 +318,94 @@ get_goal_snippet() {
 		echo "$goal"
 	fi
 }
+
+# Check if task is safe to clean (not active/failed)
+# Usage: is_task_safe_to_clean <task_dir>
+# Returns: 0 if safe to clean, 1 if should skip
+is_task_safe_to_clean() {
+	local task_dir="$1"
+	local tid
+	tid="$(basename "$task_dir")"
+
+	# Check if task has output file (completed)
+	if [[ -f "$task_dir/out" ]]; then
+		return 1
+	fi
+
+	# Check if any subtask is still in draft or waiting state (active)
+	if [[ -f "$task_dir/s" ]]; then
+		while IFS=' ' read -r _id state _retries; do
+			case "$state" in
+			d | - | f) return 1 ;; # draft, waiting, or failed = do not clean
+			esac
+		done <"$task_dir/s"
+	fi
+
+	return 0
+}
+
+# Clean tasks older than N days (skip active/failed tasks)
+# Usage: clean_tasks <days> [dry_run]
+clean_tasks() {
+	local days="${1:-30}"
+	local dry_run="${2:-false}"
+
+	if [[ ! -d "$BB_DIR" ]]; then
+		echo "No tasks found"
+		return 0
+	fi
+
+	local cleaned=0
+	while IFS= read -r task_dir; do
+		[[ -z "$task_dir" ]] && continue
+
+		if ! is_task_safe_to_clean "$task_dir"; then
+			continue
+		fi
+
+		local tid
+		tid="$(basename "$task_dir")"
+
+		if [[ "$dry_run" == "true" ]]; then
+			echo "Would clean: $tid"
+		else
+			rm -rf "$task_dir"
+			echo "Cleaned: $tid"
+		fi
+		((cleaned++)) || true
+	done < <(find "$BB_DIR" -maxdepth 1 -type d -mtime "+$days" 2>/dev/null)
+
+	echo "Cleaned $cleaned tasks older than $days days"
+}
+
+# Prune completed tasks (have out file)
+# Usage: prune_completed [dry_run]
+prune_completed() {
+	local dry_run="${1:-false}"
+
+	if [[ ! -d "$BB_DIR" ]]; then
+		echo "No tasks found"
+		return 0
+	fi
+
+	local pruned=0
+	for task_dir in "$BB_DIR"/*/; do
+		[[ -d "$task_dir" ]] || continue
+
+		# Only prune if out file exists (completed)
+		if [[ -f "$task_dir/out" ]]; then
+			local tid
+			tid="$(basename "$task_dir")"
+
+			if [[ "$dry_run" == "true" ]]; then
+				echo "Would prune: $tid"
+			else
+				rm -rf "$task_dir"
+				echo "Pruned: $tid"
+			fi
+			((pruned++)) || true
+		fi
+	done
+
+	echo "Pruned $pruned completed tasks"
+}

--- a/mnto
+++ b/mnto
@@ -40,6 +40,9 @@ source "$SCRIPT_DIR/lib/harness.bash"
 DRY_RUN="${DRY_RUN:-false}"
 VIPUNE_ENABLED="${VIPUNE_ENABLED:-false}"
 PLAN_MODEL="${PLAN_MODEL:-apfel}"
+CLEAN_MODE="${CLEAN_MODE:-false}"
+PRUNE_MODE="${PRUNE_MODE:-false}"
+CLEAN_DAYS="${CLEAN_DAYS:-30}"
 
 usage() {
 	cat <<EOF
@@ -49,10 +52,14 @@ Commands:
   mnto "goal"           Create and run new task
   mnto --resume {tid}   Resume existing task from last state
   mnto --list           List tasks with goal snippets and status
+  mnto --clean [--days N] [--dry-run]
+                        Remove tasks older than N days (default: 30)
+  mnto --prune [--dry-run]
+                        Remove completed tasks only (have output)
 
 Options:
   -h, --help            Show this help
-  --dry-run             Show prompts without calling apfel
+  --dry-run             Show actions without executing (also --clean, --prune)
   --plan-model {url}    Use external model (curl to URL or command)
   --vipune              Enable vipune semantic search integration
 EOF
@@ -226,6 +233,26 @@ parse_options() {
 			VIPUNE_ENABLED="true"
 			shift
 			;;
+		--clean)
+			CLEAN_MODE="true"
+			shift
+			;;
+		--prune)
+			PRUNE_MODE="true"
+			shift
+			;;
+		--days)
+			if [[ $# -lt 2 ]]; then
+				echo "ERROR: --days requires a number" >&2
+				exit 1
+			fi
+			if ! [[ "$2" =~ ^[0-9]+$ ]]; then
+				echo "ERROR: --days requires a positive integer" >&2
+				exit 1
+			fi
+			CLEAN_DAYS="$2"
+			shift 2
+			;;
 		-*)
 			echo "ERROR: Unknown option: $1" >&2
 			usage
@@ -264,6 +291,12 @@ main() {
 			exit 1
 		fi
 		resume_task "$2"
+		;;
+	--clean)
+		clean_tasks "$CLEAN_DAYS" "$DRY_RUN"
+		;;
+	--prune)
+		prune_completed "$DRY_RUN"
 		;;
 	*)
 		create_task "$1"


### PR DESCRIPTION
## Summary
- Implement `mnto --clean` to remove stale tasks older than N days (default 30)
- Implement `mnto --prune` to remove completed tasks only (tasks with out file)
- Add `--days N` option for custom threshold
- Add `--dry-run` preview mode
- Safety: protects active, failed, and completed tasks from removal
- Numeric validation for --days argument

## Links
- Parent epic: #14
- Fixes #17