### PR TITLE
fix(#27,#28): add idempotency guards, remove scratch file

### DIFF
--- a/lib/blackboard.bash
+++ b/lib/blackboard.bash
@@ -2,6 +2,10 @@
 # Blackboard operations for mnto
 set -euo pipefail
 
+# Idempotency guard — prevent double-sourcing
+[[ -n "${_BLACKBOARD_SOURCED:-}" ]] && return 0
+declare -r _BLACKBOARD_SOURCED=1
+
 # ANSI terminal colours (used in harness.bash via source)
 # shellcheck disable=SC2034
 readonly C_RESET='\033[0m'

--- a/lib/planner.bash
+++ b/lib/planner.bash
@@ -2,6 +2,10 @@
 # Task planning functions for mnto
 set -euo pipefail
 
+# Idempotency guard — prevent double-sourcing
+[[ -n "${_PLANNER_SOURCED:-}" ]] && return 0
+declare -r _PLANNER_SOURCED=1
+
 # System prompts for apfel
 readonly SYS_PLAN="Decompose the goal into 3-8 sections. Output one line per section:
 {id} {label}: {description}, {word limit}


### PR DESCRIPTION
## Summary
- Add idempotency guards to `lib/blackboard.bash` and `lib/planner.bash` to prevent double-sourcing readonly variable crashes (#27)
- Remove untracked scratch file `test/test-script.sh` (#28)

## Problem
The sourcing DAG created a diamond dependency: mnto sources blackboard.bash, planner.bash, and harness.bash; harness.bash also sources blackboard.bash and planner.bash. This caused `readonly variable` re-declaration errors (C_RESET, SYS_PLAN, etc.) that crashed mnto on startup under `set -euo pipefail`.

## Fix
Added guard pattern to both files:
```bash
[[ -n "${_BLACKBOARD_SOURCED:-}" ]] && return 0
declare -r _BLACKBOARD_SOURCED=1
```

This is idiomatic bash — `return 0` exits the sourced file cleanly, and `declare -r` makes the guard tamper-proof.

## Quality Gates
- ✅ bash -n: all pass
- ✅ shellcheck: 0 warnings
- ✅ shfmt: no changes needed
- ✅ bats test/: 55 passing, 1 skipped (pre-existing)
- ✅ Adversarial review: APPROVED

Fixes #27, Fixes #28