### PR TITLE
fix(#59): e2e metrics crashes with double-output under pipefail

### DIFF
--- a/test/e2e/e2e-qa.sh
+++ b/test/e2e/e2e-qa.sh
@@ -117,13 +117,13 @@ detect_backend() {
 		local detected_backend
 		detected_backend=$(extract_backend_prefix "$verifier")
 		case "$detected_backend" in
-			apfel|openai)
-				BACKEND="$detected_backend"
-				;;
-			*)
-				echo "ERROR: Unsupported backend in MNTO_VERIFIER: $detected_backend (supported: apfel, openai)" >&2
-				exit 1
-				;;
+		apfel | openai)
+			BACKEND="$detected_backend"
+			;;
+		*)
+			echo "ERROR: Unsupported backend in MNTO_VERIFIER: $detected_backend (supported: apfel, openai)" >&2
+			exit 1
+			;;
 		esac
 		return 0
 	fi
@@ -135,13 +135,13 @@ detect_backend() {
 		local detected_backend
 		detected_backend=$(extract_backend_prefix "$model")
 		case "$detected_backend" in
-			apfel|openai)
-				BACKEND="$detected_backend"
-				;;
-			*)
-				echo "ERROR: Unsupported backend in MNTO_MODEL: $detected_backend (supported: apfel, openai)" >&2
-				exit 1
-				;;
+		apfel | openai)
+			BACKEND="$detected_backend"
+			;;
+		*)
+			echo "ERROR: Unsupported backend in MNTO_MODEL: $detected_backend (supported: apfel, openai)" >&2
+			exit 1
+			;;
 		esac
 		return 0
 	fi
@@ -269,7 +269,7 @@ collect_scenario_metrics() {
 			inference_calls=0
 		fi
 
-# Count retry occurrences, with error handling for unreadable directories
+		# Count retry occurrences, with error handling for unreadable directories
 		if [[ -r "$bb_dir/${task_id}" ]]; then
 			retry_count=$(grep -r "retry" "$bb_dir/${task_id}" 2>/dev/null | wc -l) || retry_count=0
 			# Normalize: strip whitespace
@@ -277,7 +277,8 @@ collect_scenario_metrics() {
 		else
 			log "WARNING: Blackboard directory not readable: $bb_dir/${task_id}"
 			retry_count=0
-fi
+		fi
+	fi
 
 	end_time=$(now_seconds)
 	duration=$(echo "${end_time} - ${start_time}" | bc || echo "0")

--- a/test/e2e/e2e-qa.sh
+++ b/test/e2e/e2e-qa.sh
@@ -271,14 +271,13 @@ collect_scenario_metrics() {
 
 # Count retry occurrences, with error handling for unreadable directories
 		if [[ -r "$bb_dir/${task_id}" ]]; then
-			retry_count=$(grep -r "retry" "$bb_dir/${task_id}" 2>/dev/null | wc -l || echo 0)
+			retry_count=$(grep -r "retry" "$bb_dir/${task_id}" 2>/dev/null | wc -l) || retry_count=0
 			# Normalize: strip whitespace
 			retry_count=$(echo "$retry_count" | tr -d ' ')
 		else
 			log "WARNING: Blackboard directory not readable: $bb_dir/${task_id}"
 			retry_count=0
-		fi
-	fi
+fi
 
 	end_time=$(now_seconds)
 	duration=$(echo "${end_time} - ${start_time}" | bc || echo "0")

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -386,7 +386,7 @@ ghi details: Write about X, Y, and Z, then conclude"
 		((infer_call_count++)) || true
 		export INFER_CALL_COUNT="$infer_call_count"
 
-		if ((infer_call_count == 1)); then
+if ((infer_call_count == 1)); then
 			# First call (plan): return markdown headers
 			echo "## Introduction"
 			echo "## Installation"


### PR DESCRIPTION
Fixes #59

## Summary
- Move `|| echo 0` fallback outside command substitution in `collect_scenario_metrics()`
- Old: `retry_count=$(grep ... | wc -l || echo 0)` — double stdout when grep fails
- New: `retry_count=$(grep ... | wc -l) || retry_count=0` — correct fallback semantics under pipefail