### PR TITLE
fix(#63): harness robustness improvements from LFM2.5 E2E testing

### DIFF
--- a/lib/blackboard.bash
+++ b/lib/blackboard.bash
@@ -194,7 +194,7 @@ normalize_plan_output() {
 
 	# Pass 1: Extract lines with strict 3-char alphabetic ID format
 	local strict
-	strict="$(echo "$clean" | grep -E '^[a-z]{3}[[:space:]]+' || true)"
+	strict="$(echo "$clean" | grep -E '^[a-z]{3}[[:space:]]+[a-zA-Z][a-zA-Z[:space:]]*:' || true)"
 	if [[ -n "$strict" ]]; then
 		echo "$strict"
 		return 0
@@ -264,7 +264,7 @@ validate_plan_format() {
 		[[ -z "$line" ]] && continue
 		count=$((count + 1))
 		# Validate full format: "abc label: description, 100 words" (word count optional)
-		if [[ ! "$line" =~ ^[a-z]{3}[[:space:]]+[^:]+:.+$ ]]; then
+		if [[ ! "$line" =~ ^[a-z]{3}[[:space:]]+[^:]+:[[:space:]]*[^[:space:]].*$ ]]; then
 			echo "ERROR: Invalid plan format on line $count: $line" >&2
 			echo "  Expected: abc label: description[, NNN words] (3 lowercase chars for ID)" >&2
 			return 1

--- a/lib/harness.bash
+++ b/lib/harness.bash
@@ -156,23 +156,33 @@ $spec"
 
 	# Call infer verifier with SYS_VERIFY
 	local result
-	local exit_code=0
-	if ! result="$(infer verifier "$SYS_VERIFY" "$vctx" 2>/dev/null)"; then
-		exit_code=$?
-		if ((exit_code == 3)); then
+	local verify_exit=0
+	result="$(infer verifier "$SYS_VERIFY" "$vctx" 2>/dev/null)" || verify_exit=$?
+	if ((verify_exit != 0)); then
+		if ((verify_exit == 3)); then
 			echo "ERROR: guardrail blocked verification for subtask $subtask_id" >&2
 			return 1
-		elif ((exit_code == 4)); then
+		elif ((verify_exit == 4)); then
 			echo "ERROR: context overflow during verification for subtask $subtask_id" >&2
 			return 1
 		else
-			echo "ERROR: inference failed for subtask $subtask_id (exit code $exit_code)" >&2
+			echo "ERROR: inference failed for subtask $subtask_id (exit code $verify_exit)" >&2
 			return 1
 		fi
 	fi
 
-	# Parse result
-	if [[ "$result" == PASS* ]]; then
+	# Parse result — strip markdown bold/backticks, then scan all lines
+	# for PASS or FAIL verdict. apfel often echoes context back and
+	# wraps the verdict in markdown (e.g. **PASS**, ```PASS```).
+	local stripped
+	stripped="$(echo "$result" | sed 's/\*\*//g; s/`//g')"
+	local verdict
+	verdict="$(echo "$stripped" | grep -Eo '^(PASS|FAIL)' | head -1)" || true
+	if [[ -z "$verdict" ]]; then
+		reason="Verifier returned no PASS or FAIL verdict"
+		echo "$reason" >"$critique_file"
+		# treat as FAIL — fall through to retry logic below
+	elif [[ "$verdict" == "PASS" ]]; then
 		# Promote draft to final
 		mv "$draft_file" "$final_file"
 		local retries
@@ -181,9 +191,11 @@ $spec"
 		print_status "PASS" "Subtask $subtask_id verified"
 		return 0
 	else
-		# Extract reason from "FAIL: reason" - more robust parsing
+		# Extract reason from "FAIL: reason" line — search all lines
 		local reason=""
-		if [[ "$result" =~ ^FAIL:[[:space:]]*(.+)$ ]]; then
+		local fail_line
+		fail_line="$(echo "$stripped" | grep -E '^FAIL:' | head -1)" || true
+		if [[ -n "$fail_line" && "$fail_line" =~ ^FAIL:[[:space:]]*(.+)$ ]]; then
 			reason="${BASH_REMATCH[1]}"
 		else
 			reason="$result"
@@ -312,16 +324,17 @@ draft_subtask() {
 	fi
 
 	# Call infer proposer with SYS_DRAFT system prompt
-	if ! infer proposer "$SYS_DRAFT" "$ctx" "$draft_file" 2>/dev/null; then
-		local exit_code=$?
-		if ((exit_code == 3)); then
+	local draft_exit=0
+	infer proposer "$SYS_DRAFT" "$ctx" "$draft_file" 2>/dev/null || draft_exit=$?
+	if ((draft_exit != 0)); then
+		if ((draft_exit == 3)); then
 			echo "ERROR: guardrail blocked drafting for subtask $subtask_id" >&2
 			return 1
-		elif ((exit_code == 4)); then
+		elif ((draft_exit == 4)); then
 			echo "ERROR: context overflow during drafting for subtask $subtask_id" >&2
 			return 1
 		else
-			echo "ERROR: inference failed for subtask $subtask_id (exit code $exit_code)" >&2
+			echo "ERROR: inference failed for subtask $subtask_id (exit code $draft_exit)" >&2
 			return 1
 		fi
 	fi
@@ -400,7 +413,9 @@ run_harness() {
 	print_status "INFO" "Starting harness for task $tid"
 
 	# Process each subtask in order
-	while IFS=' ' read -r subtask_id rest; do
+	# NOTE: Read plan via fd 9 so child processes (apfel) don't consume
+	# the plan file through inherited stdin.
+	while IFS=' ' read -r subtask_id rest <&9; do
 		if [[ -z "$subtask_id" ]]; then
 			continue
 		fi
@@ -411,7 +426,7 @@ run_harness() {
 			echo "ERROR: Failed to process subtask $subtask_id" >&2
 			return 1
 		fi
-	done <"$plan_file"
+	done 9<"$plan_file"
 
 	# Stitch all final drafts
 	if ! stitch_task "$tid"; then

--- a/lib/openai.bash
+++ b/lib/openai.bash
@@ -89,19 +89,22 @@ _infer_openai() {
 	api_key="${MNTO_API_KEY:-${OPENAI_API_KEY:-}}"
 
 	# Build request with jq (safe JSON encoding of prompts containing special chars)
+	local max_tokens="${MNTO_MAX_TOKENS:-4096}"
 	local payload
-	payload="$(jq -n \
-		--arg model "$model" \
-		--arg sys "$system" \
-		--arg ctx "$context" \
-		'{model:$model, messages:[{role:"system",content:$sys},{role:"user",content:$ctx}]}'
+	payload="$(
+		jq -n \
+			--arg model "$model" \
+			--arg sys "$system" \
+			--arg ctx "$context" \
+			--argjson max_tokens "$max_tokens" \
+			'{model:$model, max_tokens:$max_tokens, messages:[{role:"system",content:$sys},{role:"user",content:$ctx}]}'
 	)" || return 1
 
-# Send request with secure header file to avoid exposing API key in process list
- 	local header_file=""
- 	# shellcheck disable=SC2329  # invoked via trap
- 	_cleanup_header() { [[ -n "$header_file" ]] && rm -f "$header_file"; }
- 	trap '_cleanup_header' RETURN INT TERM HUP
+	# Send request with secure header file to avoid exposing API key in process list
+	local header_file=""
+	# shellcheck disable=SC2329  # invoked via trap
+	_cleanup_header() { [[ -n "${header_file:-}" ]] && rm -f "$header_file"; }
+	trap '_cleanup_header' RETURN INT TERM HUP
 
 	local curl_auth_args=()
 	if [[ -n "$api_key" ]]; then
@@ -120,19 +123,20 @@ _infer_openai() {
 			return 1
 		}
 		umask "$old_umask"
-		chmod 600 "$header_file"  # Defense-in-depth: ensure owner-only
-		printf 'header "Authorization: Bearer %s"\n' "$api_key" > "$header_file"
+		chmod 600 "$header_file" # Defense-in-depth: ensure owner-only
+		printf 'header "Authorization: Bearer %s"\n' "$api_key" >"$header_file"
 		curl_auth_args=(--config "$header_file")
 	fi
 
 	# Use unit separator (0x1F) for robust response parsing
 	# This character won't appear in valid JSON
-	response="$(curl -sS --max-time "$timeout" \
-		-w $'\x1f%{http_code}' \
-		"${base_url}/chat/completions" \
-		-H "Content-Type: application/json" \
-		"${curl_auth_args[@]}" \
-		-d "$payload"
+	response="$(
+		curl -sS --max-time "$timeout" \
+			-w $'\x1f%{http_code}' \
+			"${base_url}/chat/completions" \
+			-H "Content-Type: application/json" \
+			"${curl_auth_args[@]}" \
+			-d "$payload"
 	)" || return 1
 
 	# Extract HTTP status code and body using parameter expansion
@@ -142,42 +146,41 @@ _infer_openai() {
 
 	# Map HTTP errors to exit codes
 	case "$http_code" in
-		200) ;; # success, continue
-		400) return 4 ;; # often token limit
-		403|451) return 3 ;; # content filter
-		*)
-			echo "ERROR: OpenAI API returned HTTP $http_code" >&2
-			return 1
-			;;
+	200) ;;                # success, continue
+	400) return 4 ;;       # often token limit
+	403 | 451) return 3 ;; # content filter
+	*)
+		echo "ERROR: OpenAI API returned HTTP $http_code" >&2
+		return 1
+		;;
 	esac
 
-	# Extract content and error in single jq pass (performance optimization)
-	local parse_result
-	parse_result="$(echo "$body" | jq -r '
-		if (.choices[0].message.content // null) != null then
-			.content = (.choices[0].message.content)
-		elif (.error.message // null) != null then
-			.error = (.error.message)
-		else
-			.error = "Unknown API error"
-		end
-		| if .content then .content else .error end
-	')" || {
-		echo "ERROR: OpenAI API: Could not parse response" >&2
-		return 1
-	}
+	# Extract content from response. Thinking models (Qwen3.x) may put
+	# the answer in content and chain-of-thought in reasoning_content.
+	# reasoning_content can contain raw control chars that break jq,
+	# so we extract content first and only fall back if empty.
+	content="$(echo "$body" | jq -r '.choices[0].message.content // empty' 2>/dev/null)" || true
 
-	# Check if result is an error (no content field present in response)
-	if ! echo "$body" | jq -e '.choices[0].message.content' >/dev/null 2>&1; then
-		echo "ERROR: OpenAI API: $parse_result" >&2
+	if [[ -z "$content" ]]; then
+		# Fallback: try reasoning_content (sanitize control chars for jq)
+		content="$(echo "$body" | tr -d '\000-\010\013\014\016-\037' | jq -r '.choices[0].message.reasoning_content // empty' 2>/dev/null)" || true
+	fi
+
+	if [[ -z "$content" ]]; then
+		# Check for API error
+		local api_error
+		api_error="$(echo "$body" | jq -r '.error.message // empty' 2>/dev/null)" || true
+		if [[ -n "$api_error" ]]; then
+			echo "ERROR: OpenAI API: $api_error" >&2
+		else
+			echo "ERROR: OpenAI API: No content in response" >&2
+		fi
 		return 1
 	fi
 
-	content="$parse_result"
-
 	# Output
 	if [[ -n "$outfile" ]]; then
-		echo "$content" > "$outfile"
+		echo "$content" >"$outfile"
 	else
 		echo "$content"
 	fi

--- a/test/e2e/scenarios/05-changelog.txt
+++ b/test/e2e/scenarios/05-changelog.txt
@@ -1,0 +1,15 @@
+Write a user-facing changelog summary from these raw git commit messages. Group by theme (fixes, features, improvements). Write in past tense, user-friendly language. Do not invent features not listed here.
+
+Commits:
+- fix: normalize_plan_output now accepts commas in descriptions
+- fix: replace double-grep with BASH_REMATCH for reliable ID extraction
+- fix: ((var++)) causes silent failure under set -e, use var=$((var+1))
+- feat: add --proposer and --verifier CLI flags for model selection
+- feat: add vipune semantic search integration for context enrichment
+- fix: e2e metrics pipeline crashes under pipefail due to double stdout
+- feat: support OpenAI-compatible backends via openai:URL:MODEL spec
+- fix: gen_id charset aligned to [a-z]{3} to match validate_id
+- chore: clarify no-CI local verification policy in CONTRIBUTING.md
+- feat: add --clean and --prune commands for task lifecycle management
+- fix: stitch_task concatenates directly when output exceeds 3000 chars
+- feat: dry-run mode shows planned actions without executing

--- a/test/e2e/scenarios/06-rewrite-informal.txt
+++ b/test/e2e/scenarios/06-rewrite-informal.txt
@@ -1,0 +1,12 @@
+Rewrite the following internal Slack thread into a polished status update suitable for a project stakeholder email. Keep all facts, dates, and names. Remove informal language, emojis, and tangents. Use professional tone.
+
+Thread:
+@alice: hey team, quick update on the migration. we got the staging env up yesterday (Apr 14) and ran the first batch of integration tests. 73 out of 80 passed which is honestly pretty good for a first run lol
+@bob: nice! the 7 failures - are those the timezone ones we talked about?
+@alice: yeah exactly, 5 of the 7 are the TZ offset bug in the billing module. the other 2 are flaky network timeouts, not real failures
+@charlie: I can pick up the TZ fix tomorrow. should be straightforward - just need to normalize to UTC before comparison
+@alice: perfect. @dave is handling the network timeout issue by adding retry logic to the API client. ETA for both fixes is end of week (Apr 18)
+@bob: so we're still on track for the Apr 25 production cutover?
+@alice: yep, assuming no surprises in the second test run. we'll do that Monday Apr 21 after the fixes land
+@charlie: btw the old system will stay in read-only mode for 2 weeks after cutover as a safety net, per the rollback plan we agreed on
+@alice: right, forgot to mention that. good call charlie

--- a/test/e2e/scenarios/07-incident-report.txt
+++ b/test/e2e/scenarios/07-incident-report.txt
@@ -1,0 +1,15 @@
+Write a structured incident report from this raw timeline. Use sections: Summary, Timeline, Root Cause, Impact, Resolution, Follow-up Actions. Be factual and concise.
+
+Raw timeline:
+14:02 - Monitoring alert: API error rate spike to 15% (normal baseline: 0.3%)
+14:05 - On-call engineer Sarah acknowledged alert, began investigation
+14:08 - Sarah identified errors coming from payment-service pod payment-svc-7b4d (HTTP 503)
+14:12 - Checked pod logs: OOM kill events, container restarting in crash loop
+14:15 - Correlated with deploy at 13:45 - new version payment-svc:v2.8.1 rolled out
+14:18 - Diff review of v2.8.1: new batch reconciliation job loads full transaction history into memory instead of streaming
+14:22 - Decision: rollback to payment-svc:v2.8.0
+14:24 - Rollback initiated via kubectl rollout undo
+14:27 - New pods healthy, error rate dropping
+14:32 - Error rate back to baseline 0.3%
+14:35 - All-clear posted to #incidents channel
+Duration: 30 minutes. Affected customers: approximately 340 payment attempts failed or timed out during the window.

--- a/test/e2e/scenarios/08-meeting-detailed.txt
+++ b/test/e2e/scenarios/08-meeting-detailed.txt
@@ -1,0 +1,15 @@
+Transform these detailed meeting notes into a structured document with: Attendees, Key Decisions, Action Items (with owners and deadlines), and Open Questions. Preserve all specifics.
+
+Meeting: Q3 Platform Roadmap Review
+Date: April 15, 2026
+Present: Lisa (Engineering Lead), Tom (Product), Priya (Infrastructure), Marcus (QA)
+
+Lisa opened by reviewing Q2 delivery: 14 of 17 planned items shipped. The 3 deferred items were the GraphQL migration, the admin dashboard redesign, and the automated canary deployment pipeline. Tom noted that the GraphQL migration was deferred because the mobile team could not commit to client-side changes until their v5.0 release ships in May.
+
+For Q3 priorities, Tom presented three themes: (1) developer experience improvements, (2) observability overhaul, and (3) self-serve onboarding for enterprise customers. Lisa raised concern about team capacity: after two departures in March, the platform team is down to 6 engineers. She proposed deferring the enterprise onboarding to Q4 unless headcount is backfilled by June 1.
+
+Priya presented the observability proposal: replace Datadog with a Grafana+Prometheus stack to reduce costs from $18k/month to approximately $4k/month. Migration would take 6-8 weeks. Marcus asked about alert parity - Priya confirmed that 90% of existing alerts can be recreated but the remaining 10% (mostly APM trace-based alerts) need custom instrumentation. Decision: proceed with observability migration, but maintain Datadog in parallel for 30 days post-migration as safety net.
+
+Marcus raised testing gaps: current E2E suite covers 62% of critical paths. He proposed adding contract tests for all inter-service APIs by end of Q3. Lisa approved, assigning Marcus 2 dedicated sprint cycles for this work starting in May.
+
+Open question: should the deferred GraphQL migration be picked back up in Q3 or wait for Q4? Tom will check with the mobile team lead by April 22 and report back.

--- a/test/harness.bats
+++ b/test/harness.bats
@@ -130,9 +130,14 @@ mock_infer() {
 		echo "abc Introduction: An overview"
 	} >"$BB_DIR/tst/abc/ctx"
 
-	# Mock infer
+	# Mock infer — write to output file (4th arg) like the real implementation
 	infer() {
-		echo "Draft content for section"
+		local outfile="${4:-}"
+		if [[ -n "$outfile" ]]; then
+			echo "Draft content for section" >"$outfile"
+		else
+			echo "Draft content for section"
+		fi
 	}
 
 	draft_subtask "tst" "abc"
@@ -447,12 +452,21 @@ mock_infer() {
 	echo "Goal" >"$BB_DIR/tst/g"
 	echo "abc - 0" >"$BB_DIR/tst/s"
 
-	# Mock infer - echo last arg for SYS_STITCH, fail for others
+	# Mock infer — write to output file (4th arg) like the real implementation.
+	# For stitch: echo content. For draft: write draft file. For verify: return FAIL.
 	infer() {
-		if [[ "$*" == *"$SYS_STITCH"* ]]; then
-			# Last positional argument is the content
-			echo "${@: -1}"
+		local role="$1"
+		local system="$2"
+		local context="$3"
+		local outfile="${4:-}"
+		if [[ "$system" == *"Combine the sections"* ]]; then
+			# Stitch call — echo content
+			echo "$context"
+		elif [[ -n "$outfile" ]]; then
+			# Draft call — write to file
+			echo "Draft that always fails verification" >"$outfile"
 		else
+			# Verify call — always fail
 			echo "FAIL: Always fails"
 		fi
 	}

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -289,10 +289,10 @@ ghi Conclusion: Summary, 50 words"
 @test "normalize_plan_output handles mixed input" {
 	source "$MNTO/lib/blackboard.bash"
 	local result
-	result=$(printf '1. abc Task 1\n- def Task 2\nghi Task 3\n' | normalize_plan_output)
-	[[ "$result" == *"abc Task 1"* ]]
-	[[ "$result" == *"def Task 2"* ]]
-	[[ "$result" == *"ghi Task 3"* ]]
+	result=$(printf '1. abc intro: Task one overview\n- def setup: Task two details\nghi usage: Task three guide\n' | normalize_plan_output)
+	[[ "$result" == *"abc intro: Task one overview"* ]]
+	[[ "$result" == *"def setup: Task two details"* ]]
+	[[ "$result" == *"ghi usage: Task three guide"* ]]
 }
 
 @test "normalize_plan_output handles id1-style IDs" {


### PR DESCRIPTION
Fixes #63

## Summary
- Verdict parsing strips markdown formatting before scanning for PASS/FAIL (handles LFM2.5 wrapping verdicts in **bold** or backticks)
- fd 9 for plan file in run_harness() prevents child infer processes consuming plan via inherited stdin
- Empty verdict guard: treat no-verdict response as FAIL with explicit reason
- normalize_plan_output Pass 1 regex requires label:colon pattern
- validate_plan_format requires non-empty description after colon
- MNTO_MAX_TOKENS env var support in OpenAI backend
- Better Qwen3/thinking model response parsing (reasoning_content fallback)
- Fix _cleanup_header unset variable guard
- Updated infer mocks in harness.bats to match real 4-arg signature
- Added E2E scenarios 05-08