### PR TITLE
fix(#61): detect duplicate subtask IDs in validate_plan_format

### DIFF
--- a/lib/blackboard.bash
+++ b/lib/blackboard.bash
@@ -260,22 +260,26 @@ validate_plan_format() {
 	# generate_plan() handles normalization before this function is called.
 
 	local count=0
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
+	declare -A seen_ids
+	while IFS=' ' read -r id rest; do
+		[[ -z "$id" ]] && continue
 		count=$((count + 1))
-		# Validate full format: "abc label: description, 100 words" (word count optional)
+		local line="$id $rest"
 		if [[ ! "$line" =~ ^[a-z]{3}[[:space:]]+[^:]+:[[:space:]]*[^[:space:]].*$ ]]; then
 			echo "ERROR: Invalid plan format on line $count: $line" >&2
 			echo "  Expected: abc label: description[, NNN words] (3 lowercase chars for ID)" >&2
 			return 1
 		fi
+		if [[ "${seen_ids[$id]:-}" == "1" ]]; then
+			echo "ERROR: Duplicate subtask ID '$id' on line $count" >&2
+			return 1
+		fi
+		seen_ids[$id]=1
 	done <<<"$plan"
-
 	if ((count < 3)); then
 		echo "ERROR: Plan needs at least 3 sections, got $count" >&2
 		return 1
 	fi
-
 	return 0
 }
 

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -408,3 +408,26 @@ if ((infer_call_count == 1)); then
 	[[ "$result" == *"def Installation"* ]]
 	[[ "$result" == *"ghi Usage"* ]]
 }
+
+@test "validate_plan_format rejects duplicate subtask IDs" {
+	source "$MNTO/lib/blackboard.bash"
+	local plan
+	plan="abc First task: Overview, 100 words
+abc Second task: Different description, 150 words
+ghi Third task: Final section, 200 words"
+	# Should fail with non-zero exit due to duplicate "abc"
+	run validate_plan_format "$plan"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Duplicate subtask ID 'abc'"* ]]
+}
+
+@test "validate_plan_format accepts plan with unique IDs" {
+	source "$MNTO/lib/blackboard.bash"
+	local plan
+	plan="abc First task: Overview, 100 words
+def Second task: Different description, 150 words
+ghi Third task: Final section, 200 words"
+	# Should succeed with zero exit
+	run validate_plan_format "$plan"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Fixes #61

## Summary
- Add associative array duplicate detection in `validate_plan_format()`
- Reject plans where any subtask ID appears more than once
- On failure, two-pass fallback in generate_plan() retries with the model
- Added 2 integration tests: duplicate rejection and unique ID acceptance