### PR TITLE
fix(#62): improve SYS_STITCH prompt and raise concatenation threshold to 10000

### DIFF
--- a/lib/planner.bash
+++ b/lib/planner.bash
@@ -37,12 +37,6 @@ Output FAIL: {one-line reason} if not. Be strict but fair.
 Only fail for: missing required content, exceeding word limit
 by >50%, incoherent text. Do not fail for style preferences."
 
-# shellcheck disable=SC2034
-readonly SYS_STITCH="Merge the sections below into a single coherent document. \
-Remove all duplicate and redundant content — keep each section's unique key \
-points only. Add brief transitions where needed. Do not add new content. \
-Output only the merged document."
-
 # Generate plan from goal using infer planner
 # Usage: generate_plan "<goal>"
 generate_plan() {

--- a/lib/planner.bash
+++ b/lib/planner.bash
@@ -38,10 +38,10 @@ Only fail for: missing required content, exceeding word limit
 by >50%, incoherent text. Do not fail for style preferences."
 
 # shellcheck disable=SC2034
-readonly SYS_STITCH="Combine the sections below into a single coherent document.
-Add brief transitions between sections if needed. Fix any
-inconsistencies. Do not add new content. Output only the
-final document."
+readonly SYS_STITCH="Merge the sections below into a single coherent document. \
+Remove all duplicate and redundant content — keep each section's unique key \
+points only. Add brief transitions where needed. Do not add new content. \
+Output only the merged document."
 
 # Generate plan from goal using infer planner
 # Usage: generate_plan "<goal>"

--- a/lib/stitcher.bash
+++ b/lib/stitcher.bash
@@ -72,7 +72,7 @@ stitch_task() {
 		return 0
 	fi
 
-	if ((total_len < 3000)); then
+	if ((total_len < 10000)); then
 		# Use infer to combine
 		local buffer
 		buffer="$(cat "$tmp_out")"

--- a/lib/stitcher.bash
+++ b/lib/stitcher.bash
@@ -12,6 +12,12 @@ fi
 # shellcheck disable=SC2317
 declare -r _STITCHER_SOURCED=1
 
+# System prompt for stitching sections together
+readonly SYS_STITCH="Merge the sections below into a single coherent document. \
+Remove all duplicate and redundant content — keep each section's unique key \
+points only. Add brief transitions where needed. Do not add new content. \
+Output only the merged document."
+
 # Stitch all final drafts into final output
 # Usage: stitch_task <tid>
 # Reads: .mnto/bb/{tid}/p (plan), .mnto/bb/{tid}/{subtask_id}/f (final drafts)
@@ -72,7 +78,7 @@ stitch_task() {
 		return 0
 	fi
 
-	if ((total_len < 10000)); then
+	if ((total_len < ${STITCH_THRESHOLD:-10000})); then
 		# Use infer to combine
 		local buffer
 		buffer="$(cat "$tmp_out")"

--- a/test/harness.bats
+++ b/test/harness.bats
@@ -350,7 +350,7 @@ mock_infer() {
 	output="$(cat "$BB_DIR/tst/out")"
 }
 
-@test "stitch_task uses infer when under 3000 chars" {
+@test "stitch_task uses infer when under 10000 chars" {
 	source_harness
 
 	mkdir -p "$BB_DIR/tst/abc"
@@ -369,14 +369,14 @@ mock_infer() {
 	[[ "$output" == *"Combined by infer"* ]]
 }
 
-@test "stitch_task concatenates directly when over 3000 chars" {
+@test "stitch_task concatenates directly when over 10000 chars" {
 	source_harness
 
 	mkdir -p "$BB_DIR/tst/abc"
 	echo "abc Long: Detailed section" >"$BB_DIR/tst/p"
-	# Create content > 3000 chars
+	# Create content > 10000 chars
 	local large_content
-	printf -v large_content 'A%.0s' {1..4000}
+	large_content="$(head -c 11000 /dev/zero | tr '\0' 'A')"
 	echo "$large_content" >"$BB_DIR/tst/abc/f"
 
 	infer() {


### PR DESCRIPTION
Fixes #62

## Summary
- Update SYS_STITCH prompt to explicitly instruct model to remove duplicate/redundant content
- Raise direct-concatenation threshold from 3000 to 10000 chars so LLM merge path is used for most real documents
- Update tests to reflect new threshold