### PR TITLE
fix(#58): Ollama model parsing for colon-containing names + --backend ollama shorthand

### DIFF
--- a/lib/openai.bash
+++ b/lib/openai.bash
@@ -18,15 +18,20 @@ _parse_openai_spec() {
 	# Strip "openai:" prefix
 	local url_and_model="${spec#openai:}"
 
-	# Extract base URL and model by splitting on last colon
-	# Base URL is everything before the last colon, model is everything after
-	# This handles: http://localhost:11434/v1:gpt-4 and model names with colons
-	local base_url="${url_and_model%:*}"
-	local model="${url_and_model##*:}"
+	# Parse URL and model using BASH_REMATCH regex
+	# Pattern: (scheme://host(/path)?)(:model)?
+	# Handles model names with colons like gemma4:e4b
+	local base_url model
+	if [[ "$url_and_model" =~ ^(https?://[^/]+(/[^:]*)?)(:(.+))?$ ]]; then
+		base_url="${BASH_REMATCH[1]}"
+		model="${BASH_REMATCH[4]:-}"
+	else
+		echo "ERROR: Invalid backend spec. Expected: openai:<url>:<model>" >&2
+		return 1
+	fi
 
-	# Validate that both segments are non-empty after stripping "openai:" prefix
-	if [[ -z "$base_url" || -z "$model" ]]; then
-		echo "ERROR: Could not parse backend spec: $1" >&2
+	if [[ -z "$model" ]]; then
+		echo "ERROR: No model specified in backend spec" >&2
 		return 1
 	fi
 

--- a/test/e2e/e2e-qa.sh
+++ b/test/e2e/e2e-qa.sh
@@ -44,6 +44,7 @@ OPTIONS:
 BACKEND SELECTION:
     --backend apfel        Use apfel CLI for inference
     --backend openai       Use OpenAI API for inference (requires OPENAI_API_KEY or MNTO_API_KEY)
+    --backend ollama      Use Ollama with OpenAI compat API (uses E2E_OLLAMA_MODEL env var)
 
     Backend precedence (from highest to lowest):
     1. --backend flag (explicit override, takes precedence)
@@ -53,11 +54,15 @@ BACKEND SELECTION:
 
     When --backend is provided, it overrides any existing MNTO_MODEL for this run.
 
+ENVIRONMENT VARIABLES:
+    E2E_OLLAMA_MODEL   Model name for ollama backend (default: gemma4:e4b)
+
 EXAMPLES:
     e2e-qa.sh                    # Run all scenarios with auto-detected backend
     e2e-qa.sh --scenario 01      # Run only scenario 01
     e2e-qa.sh --backend openai   # Run all scenarios with OpenAI backend
-    e2e-qa.sh --dry-run           # Preview scenarios to run
+    e2e-qa.sh --backend ollama   # Run all scenarios with Ollama backend
+    e2e-qa.sh --dry-run          # Preview scenarios to run
 
 EOF
 }
@@ -117,11 +122,11 @@ detect_backend() {
 		local detected_backend
 		detected_backend=$(extract_backend_prefix "$verifier")
 		case "$detected_backend" in
-		apfel | openai)
+		apfel | openai | ollama)
 			BACKEND="$detected_backend"
 			;;
 		*)
-			echo "ERROR: Unsupported backend in MNTO_VERIFIER: $detected_backend (supported: apfel, openai)" >&2
+			echo "ERROR: Unsupported backend in MNTO_VERIFIER: $detected_backend (supported: apfel, openai, ollama)" >&2
 			exit 1
 			;;
 		esac
@@ -135,11 +140,11 @@ detect_backend() {
 		local detected_backend
 		detected_backend=$(extract_backend_prefix "$model")
 		case "$detected_backend" in
-		apfel | openai)
+		apfel | openai | ollama)
 			BACKEND="$detected_backend"
 			;;
 		*)
-			echo "ERROR: Unsupported backend in MNTO_MODEL: $detected_backend (supported: apfel, openai)" >&2
+			echo "ERROR: Unsupported backend in MNTO_MODEL: $detected_backend (supported: apfel, openai, ollama)" >&2
 			exit 1
 			;;
 		esac
@@ -173,8 +178,14 @@ check_backend_dependencies() {
 			exit 1
 		fi
 		;;
+	ollama)
+		if ! command -v curl &>/dev/null; then
+			echo "ERROR: curl not found in PATH (required for ollama backend)"
+			exit 1
+		fi
+		;;
 	*)
-		echo "ERROR: Unknown backend: $BACKEND (supported: apfel, openai)"
+		echo "ERROR: Unknown backend: $BACKEND (supported: apfel, openai, ollama)"
 		exit 1
 		;;
 	esac
@@ -221,6 +232,11 @@ collect_scenario_metrics() {
 		if [[ "$BACKEND_EXPLICIT" == true ]] || [[ -z "${MNTO_MODEL:-}" ]]; then
 			_warn_on_backend_override "apfel"
 			export MNTO_MODEL="apfel"
+		fi
+	elif [[ "$BACKEND" == "ollama" ]]; then
+		if [[ "$BACKEND_EXPLICIT" == true ]] || [[ -z "${MNTO_MODEL:-}" ]]; then
+			_warn_on_backend_override "ollama"
+			export MNTO_MODEL="openai:http://localhost:11434/v1:${E2E_OLLAMA_MODEL:-gemma4:e4b}"
 		fi
 	fi
 

--- a/test/openai.bats
+++ b/test/openai.bats
@@ -89,6 +89,14 @@ teardown() {
 	assert_equal "$model" "qwen3:30b-a3b:latest"
 }
 
+# Test _parse_openai_spec handles gemma4:e4b style model names (issue #58)
+@test "_parse_openai_spec parses gemma4:e4b model name" {
+	local spec="openai:http://localhost:11434/v1:gemma4:e4b"
+	_parse_openai_spec "$spec" | IFS=$'\t' read -r base_url model
+	assert_equal "$base_url" "http://localhost:11434/v1"
+	assert_equal "$model" "gemma4:e4b"
+}
+
 # Test _parse_openai_spec with HTTPS
 @test "_parse_openai_spec parses HTTPS URL" {
 	local spec="openai:https://api.openai.com/v1:gpt-4o-mini"


### PR DESCRIPTION
Fixes #58

## Summary
- Replace last-colon splitting with BASH_REMATCH regex in _parse_openai_spec() — correctly handles model names like gemma4:e4b
- Add --backend ollama shorthand to e2e-qa.sh (defaults to localhost:11434 with gemma4:e4b)
- Document E2E_OLLAMA_MODEL env var in --help output
- Add test for gemma4:e4b model name parsing