### PR TITLE
fix(#38): validate bb_dir path before rm -rf to prevent traversal

### DIFF
--- a/mnto
+++ b/mnto
@@ -151,6 +151,12 @@ create_task() {
 	plan="$(generate_plan "$goal")"
 	plan_result=$?
 
+	# Validate bb_dir before any cleanup (guards both error paths below)
+	if ! _validate_bb_path "$bb_dir"; then
+		echo "ERROR: Refusing to remove invalid path: $bb_dir" >&2
+		exit 1
+	fi
+
 	if [[ $plan_result -ne 0 ]]; then
 		# Exit code from generate_plan contains the error reason
 		rm -rf "$bb_dir"


### PR DESCRIPTION
Fixes #38

## Summary
- Add _validate_bb_path() to lib/blackboard.bash — validates path is within BB_DIR and rejects ../ components
- String-based check only (symlinks within BB_DIR pointing outside not detected — acceptable MVP tradeoff, documented in comment)
- Call validation in is_task_safe_to_clean() in maintenance.bash before rm -rf
- 3 integration tests added