### PR TITLE
fix(#69): add model name whitelist validation in _parse_openai_spec

### DIFF
--- a/lib/openai.bash
+++ b/lib/openai.bash
@@ -35,6 +35,12 @@ _parse_openai_spec() {
 		return 1
 	fi
 
+	# Validate model name contains only safe characters (whitelist approach)
+	if [[ ! "$model" =~ ^[-a-zA-Z0-9._:/]+$ ]]; then
+		echo "ERROR: Invalid model name format: $model (allowed: alphanumeric, hyphens, dots, colons, underscores, forward-slashes)" >&2
+		return 1
+	fi
+
 	# Validate URL scheme to prevent SSRF
 	if [[ ! "$base_url" =~ ^https?:// ]]; then
 		echo "ERROR: Invalid URL scheme in backend spec" >&2

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -431,3 +431,29 @@ ghi Third task: Final section, 200 words"
 	run validate_plan_format "$plan"
 	[ "$status" -eq 0 ]
 }
+
+# === Model name validation tests (issue #69) ===
+
+@test "_parse_openai_spec accepts gemma4:e4b model name" {
+	source "$MNTO/lib/openai.bash"
+	local spec="openai:http://localhost:11434/v1:gemma4:e4b"
+	run _parse_openai_spec "$spec"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"gemma4:e4b" ]]
+}
+
+@test "_parse_openai_spec rejects model with dollar sign" {
+	source "$MNTO/lib/openai.bash"
+	local spec="openai:http://localhost:11434/v1:model\$evil"
+	run _parse_openai_spec "$spec"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Invalid model name format"* ]]
+}
+
+@test "_parse_openai_spec rejects model with spaces" {
+	source "$MNTO/lib/openai.bash"
+	local spec="openai:http://localhost:11434/v1:model name"
+	run _parse_openai_spec "$spec"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Invalid model name format"* ]]
+}


### PR DESCRIPTION
Fixes #69

## Summary
- Whitelist validation after model name extraction in _parse_openai_spec()
- Regex ^[-a-zA-Z0-9._:/]+$ allows alphanumeric, hyphens, dots, colons, underscores, forward-slashes
- Rejects shell metacharacters: spaces, dollar signs, backticks, parens, etc.
- 3 integration tests added (valid model, dollar sign rejected, space rejected)