### PR TITLE
feat(#75): redesign planner for dependency-aware workflow steps

### DIFF
--- a/lib/blackboard.bash
+++ b/lib/blackboard.bash
@@ -69,7 +69,7 @@ next_task() {
 		return 1
 	fi
 
-	while IFS=' ' read -r id state retries; do
+	while IFS=' ' read -r id state _retries _deps; do
 		if [[ "$state" == "-" ]]; then
 			echo "$id"
 			return 0
@@ -81,12 +81,13 @@ next_task() {
 }
 
 # Update status file for subtask
-# Usage: set_status <tid> <id> <state> <retries>
+# Usage: set_status <tid> <id> <state> <retries> [deps]
 set_status() {
 	local tid="$1"
 	local id="$2"
 	local state="$3"
 	local retries="$4"
+	local deps="${5:-}"
 	if ! validate_id "$tid"; then
 		return 1
 	fi
@@ -105,11 +106,11 @@ set_status() {
 		return 1
 	fi
 
-	while IFS=' ' read -r cur_id cur_state cur_retries; do
+	while IFS=' ' read -r cur_id cur_state cur_retries cur_deps; do
 		if [[ "$cur_id" == "$id" ]]; then
-			echo "$id $state $retries"
+			echo "$id $state $retries ${deps:-$cur_deps}"
 		else
-			echo "$cur_id $cur_state $cur_retries"
+			echo "$cur_id $cur_state $cur_retries ${cur_deps:-}"
 		fi
 	done <"$status_file" >"$tmp_file"
 
@@ -291,6 +292,7 @@ validate_plan_format() {
 }
 
 # Fill in missing word counts with default value
+# Also ensure deps: suffix is present on each line (appended if missing)
 # Usage: fill_missing_word_counts <plan>
 fill_missing_word_counts() {
 	local plan="$1"
@@ -304,6 +306,17 @@ fill_missing_word_counts() {
 		if [[ "$line" =~ ^[a-z]{3}[[:space:]]+[[:alpha:]][[:alpha:][:space:]]*:.+ ]] && [[ ! "$line" =~ ,[[:space:]]*[0-9]+[[:space:]]*words[[:space:]]*$ ]]; then
 			line="${line}, 100 words"
 		fi
+		# Ensure deps: suffix is present (append if missing)
+		if [[ "$line" =~ ^[^,]*[[:space:]]words[[:space:]]*,[[:space:]]*deps: ]]; then
+			# deps: already present, preserve as-is
+			:
+		elif [[ "$line" =~ ^.*[[:space:]]words[[:space:]]* ]]; then
+			# Has word count but no deps: — append deps:
+			line="${line}, deps:"
+		else
+			# No word count and no deps — add both
+			line="${line}, 100 words, deps:"
+		fi
 		result+="${line}"$'\n'
 	done <<<"$plan"
 
@@ -311,6 +324,7 @@ fill_missing_word_counts() {
 }
 
 # Parse plan and create subtask structure
+# Status file entries: "id state retries deps" (deps is comma-separated, or empty for root)
 # Usage: parse_plan <plan> <tid>
 parse_plan() {
 	local plan="$1"
@@ -333,6 +347,7 @@ parse_plan() {
 	echo "$plan" >"$plan_file"
 
 	# Initialize status file with waiting state
+	# Format: id state retries deps (deps from plan line, comma-separated or empty)
 	while IFS=' ' read -r id rest; do
 		if [[ -z "$id" ]]; then
 			continue
@@ -342,7 +357,12 @@ parse_plan() {
 			echo "ERROR: Invalid subtask ID: $id (must be exactly 3 lowercase chars)" >&2
 			return 1
 		fi
-		echo "$id - 0"
+		# Extract deps from the deps: field (last comma-separated field)
+		local deps=""
+		if [[ "$rest" =~ deps:[[:space:]]*([a-z,]*)[[:space:]]*$ ]]; then
+			deps="${BASH_REMATCH[1]:-}"
+		fi
+		echo "$id - 0 $deps"
 		mkdir -p "$bb_dir/$id"
 	done <"$plan_file" >"$status_file"
 }
@@ -363,7 +383,7 @@ count_subtasks() {
 	fi
 
 	local w=0 d=0 c=0 fail=0
-	while IFS=' ' read -r _id state _retries; do
+	while IFS=' ' read -r _id state _retries _deps; do
 		case "$state" in
 		-) w=$((w + 1)) ;;
 		d) d=$((d + 1)) ;;
@@ -435,4 +455,33 @@ get_goal_snippet() {
 	else
 		echo "$goal"
 	fi
+}
+
+# Get dependencies for a subtask
+# Usage: get_task_deps <tid> <subtask_id>
+# Returns: comma-separated dep IDs, or empty string for root steps
+get_task_deps() {
+	local tid="$1"
+	local subtask_id="$2"
+	if ! validate_id "$tid"; then
+		echo ""
+		return 1
+	fi
+	if ! validate_id "$subtask_id"; then
+		echo ""
+		return 1
+	fi
+	local status_file="$BB_DIR/$tid/s"
+	if [[ ! -f "$status_file" ]]; then
+		echo ""
+		return 0
+	fi
+	while IFS=' ' read -r id _state _retries deps; do
+		if [[ "$id" == "$subtask_id" ]]; then
+			echo "${deps:-}"
+			return 0
+		fi
+	done <"$status_file"
+	echo ""
+	return 0
 }

--- a/lib/harness.bash
+++ b/lib/harness.bash
@@ -163,8 +163,11 @@ verify_subtask() {
 
 	# Quick bash pre-check: fail fast on empty or trivially bad drafts
 	# without wasting an LLM verification call.
+	# 10 chars is below any meaningful sentence fragment; catches empty output,
+	# single-word responses, and inference errors that produce minimal text.
+	local min_draft_len="${MNTO_MIN_DRAFT_LEN:-10}"
 	local draft_len=${#draft}
-	if ((draft_len < 10)); then
+	if ((draft_len < min_draft_len)); then
 		echo "Draft too short (${draft_len} chars)" >"$critique_file"
 		local retries
 		retries="$(get_retries "$tid" "$subtask_id")"

--- a/lib/planner.bash
+++ b/lib/planner.bash
@@ -9,34 +9,36 @@ declare -r _PLANNER_SOURCED=1
 # System prompts — tuned for small LLMs (1.2B-3B params).
 # Uses positive framing, explicit ID sequence, and 5 diverse examples
 # to maximize format compliance via pattern completion.
-readonly SYS_PLAN="Write a plan. Each line: three-letter ID, space, label, colon, description, comma, word count.
+readonly SYS_PLAN="Write a plan. Each line: three-letter ID, space, label, colon, description, comma, word count, comma, deps.
 
 Use these IDs in order: zab, zcd, zef, zij, zkl, zmn, zop, zqr
 
 Example output for \"build a treehouse\":
-zab planning: Choose a tree and gather materials, 100 words
-zcd foundation: Build the base platform securely, 150 words
-zef walls: Construct walls and add windows, 150 words
-zij roof: Add weatherproof roofing, 100 words
-zkl finishing: Paint and add a rope ladder, 100 words
+zab planning: Choose a tree and gather materials, 100 words, deps:
+zcd foundation: Build the base platform securely, 150 words, deps: zab
+zef walls: Construct walls and add windows, 150 words, deps: zcd
+zij roof: Add weatherproof roofing, 100 words, deps: zef
+zkl finishing: Paint and add a rope ladder, 100 words, deps: zij
 
 Write 3 to 8 lines. Only plan lines, nothing else."
 
 # Two-pass fallback: reformat raw output into plan lines
-readonly SYS_RESTRUCTURE="Rewrite the text below as a plan. Each line: three-letter ID, space, label, colon, description, comma, word count.
+readonly SYS_RESTRUCTURE="Rewrite the text below as a plan. Each line: three-letter ID, space, label, colon, description, comma, word count, comma, deps.
 
 Use these IDs in order: zab, zcd, zef, zij, zkl, zmn, zop, zqr
 
 Example line:
-zab overview: Brief summary of the topic, 100 words
+zab overview: Brief summary of the topic, 100 words, deps:
+zcd details: Key information and steps, 150 words, deps: zab
+zef conclusion: Summary and next steps, 100 words, deps: zcd
 
 Write one line per section. Only plan lines, nothing else."
 
 # Emergency fallback: minimal prompt for pure pattern completion
 readonly SYS_PLAN_MINIMAL="Write a plan like this:
-zab first: Description here, 100 words
-zcd second: Description here, 100 words
-zef third: Description here, 100 words
+zab first: Description here, 100 words, deps:
+zcd second: Description here, 100 words, deps: zab
+zef third: Description here, 100 words, deps: zcd
 
 Write 3 to 5 lines about the topic below."
 
@@ -58,9 +60,9 @@ Do not fail for style preferences. Be strict but fair."
 
 # Fixed template fallback — guarantees the harness always runs even when
 # the LLM cannot produce a valid dynamic plan.
-readonly PLAN_TEMPLATE_GENERIC="zab introduction: Opening section that introduces the topic, 100 words
-zcd body: Main content covering the key points in detail, 200 words
-zef conclusion: Summary and closing thoughts, 100 words"
+readonly PLAN_TEMPLATE_GENERIC="zab introduction: Opening section that introduces the topic, 100 words, deps:
+zcd body: Main content covering the key points in detail, 200 words, deps: zab
+zef conclusion: Summary and closing thoughts, 100 words, deps: zcd"
 
 # Try to normalize and validate a raw plan output.
 # Usage: result="$(_try_normalize "$raw_output")"
@@ -88,7 +90,15 @@ _plan_infer() {
 	local goal="$2"
 	local ec=0
 	local out
-	out="$(infer planner "$sys" "$goal" 2>/dev/null)" || ec=$?
+
+	# MNTO_PLANNER_MODEL takes precedence over role-based model resolution
+	# for planning inference only. Falls back to infer planner otherwise.
+	if [[ -n "${MNTO_PLANNER_MODEL:-}" ]]; then
+		local backend="$MNTO_PLANNER_MODEL"
+		out="$(infer_with_backend "$backend" planner "$sys" "$goal" 2>/dev/null)" || ec=$?
+	else
+		out="$(infer planner "$sys" "$goal" 2>/dev/null)" || ec=$?
+	fi
 
 	if ((ec == 3)); then
 		echo "ERROR: guardrail blocked the request" >&2
@@ -101,6 +111,45 @@ _plan_infer() {
 		return 1
 	fi
 	echo "$out"
+}
+
+# Invoke infer with explicit backend instead of role-based dispatch
+# Usage: out="$(infer_with_backend "$backend" "$role" "$system" "$context")"
+infer_with_backend() {
+	local backend="$1"
+	local role="$2"
+	local system="$3"
+	local context="$4"
+	local outfile="${5:-}"
+
+	# Mirror temperature injection from backend.bash:infer()
+	local temperature
+	case "$role" in
+	planner | verifier) temperature="${MNTO_TEMP_STRUCTURED:-0.2}" ;;
+	proposer | stitcher) temperature="${MNTO_TEMP_CREATIVE:-0.7}" ;;
+	*) temperature="0.7" ;;
+	esac
+	export MNTO_TEMPERATURE="$temperature"
+
+	# Unified validation and dispatch via backend type
+	local backend_type="${backend%%:*}"
+	case "$backend_type" in
+	apfel)
+		_infer_apfel "$system" "$context" "$outfile"
+		;;
+	openai)
+		if _valid_openai_spec "$backend"; then
+			_infer_openai "$backend" "$system" "$context" "$outfile"
+		else
+			echo "ERROR: OpenAI backend requires spec format openai:URL:MODEL" >&2
+			return 1
+		fi
+		;;
+	*)
+		echo "ERROR: Invalid backend specification: $backend" >&2
+		return 1
+		;;
+	esac
 }
 
 # Generate plan from goal using infer planner
@@ -132,6 +181,7 @@ generate_plan() {
 			local ec=$?
 			# Propagate guardrail/overflow, but retry on generic failure
 			if ((ec == 3 || ec == 4)); then
+				export MNTO_TEMP_STRUCTURED="$saved_temp"
 				echo ""
 				return "$ec"
 			fi
@@ -139,6 +189,7 @@ generate_plan() {
 		}
 
 		if result="$(_try_normalize "$raw_output")"; then
+			export MNTO_TEMP_STRUCTURED="$saved_temp"
 			echo "$result"
 			return 0
 		fi

--- a/test/harness.bats
+++ b/test/harness.bats
@@ -285,7 +285,8 @@ mock_infer() {
 	source_harness
 
 	mkdir -p "$BB_DIR/tst/abc"
-	echo "abc c 1" >"$BB_DIR/tst/s"
+	# Status file now has 4 fields: id state retries deps
+	echo "abc c 1 " >"$BB_DIR/tst/s"
 
 	run handle_retry "tst" "abc" 3
 	[ "$status" -eq 0 ]
@@ -296,7 +297,7 @@ mock_infer() {
 
 	local status
 	status=$(grep "^abc" "$BB_DIR/tst/s")
-	[[ "$status" == "abc c 2" ]]
+	[[ "$status" == "abc c 2 "* ]]
 }
 
 @test "handle_retry accepts draft after max retries" {

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -194,12 +194,13 @@ teardown() {
 	source "$MNTO/lib/blackboard.bash"
 
 	echo -e "abc Task A\ndef Task B" >"$BB_DIR/xyz/p"
-	echo -e "abc - 0\ndef - 0" >"$BB_DIR/xyz/s"
+	# Status file now has 4 fields: id state retries deps
+	echo -e "abc - 0 \ndef - 0 " >"$BB_DIR/xyz/s"
 
 	set_status "xyz" "abc" "d" "0"
 
 	local expected
-	expected=$(echo -e "abc d 0\ndef - 0")
+	expected=$(echo -e "abc d 0 \ndef - 0 ")
 	local actual
 	actual=$(cat "$BB_DIR/xyz/s")
 

--- a/test/planner.bats
+++ b/test/planner.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+# Planner redesign tests: dependency-aware workflow steps + MNTO_PLANNER_MODEL
+
+setup() {
+	export MNTO="${BATS_TEST_DIRNAME}/.."
+	export TEST_BB_DIR="$BATS_TMPDIR/mnto-planner-$BATS_TEST_NUMBER"
+	export BB_DIR="$TEST_BB_DIR/.bb"
+	mkdir -p "$BB_DIR"
+}
+
+teardown() {
+	rm -rf "$TEST_BB_DIR"
+}
+
+source_libs() {
+	source "$MNTO/lib/blackboard.bash"
+	source "$MNTO/lib/backend.bash"
+	source "$MNTO/lib/planner.bash"
+}
+
+# ============ Dependencies parsing tests ============
+
+@test "parse_plan writes deps as 4th field in status file" {
+	source_libs
+
+	local plan
+	plan="zab overview: Brief summary, 50 words, deps:
+zcd details: Key information, 100 words, deps: zab
+zef conclusion: Summary, 50 words, deps: zcd"
+
+	parse_plan "$plan" "xyz"
+
+	local status_content
+	status_content=$(cat "$BB_DIR/xyz/s")
+	# zab has no deps, zcd depends on zab, zef depends on zcd
+	[[ "$status_content" == *"zab - 0 "* ]]
+	[[ "$status_content" == *"zcd - 0 zab"* ]]
+	[[ "$status_content" == *"zef - 0 zcd"* ]]
+}
+
+@test "parse_plan with empty deps (root step) writes 4th field as empty" {
+	source_libs
+
+	# Must have at least 3 sections per validate_plan_format
+	local plan
+	plan="zab root: First step, 50 words, deps:
+zcd second: Second step, 50 words, deps: zab
+zef third: Third step, 50 words, deps: zcd"
+
+	parse_plan "$plan" "xyz"
+
+	local status_content
+	status_content=$(cat "$BB_DIR/xyz/s")
+	local first_line
+	first_line="$(echo "$status_content" | head -1)"
+	# zab has empty deps - first field should end with space after "0"
+	[[ "$first_line" == "zab - 0 " ]]
+}
+
+@test "get_task_deps returns correct dep IDs" {
+	source_libs
+
+	mkdir -p "$BB_DIR/xyz/abc"
+	echo "zab - 0 " >"$BB_DIR/xyz/s"
+	echo "abc - 0 zab,zcd" >>"$BB_DIR/xyz/s"
+	echo "def - 0 zcd" >>"$BB_DIR/xyz/s"
+
+	local deps
+	deps="$(get_task_deps "xyz" "abc")"
+	[[ "$deps" == "zab,zcd" ]]
+}
+
+@test "get_task_deps returns empty for root step" {
+	source_libs
+
+	mkdir -p "$BB_DIR/xyz/abc"
+	echo "abc - 0 " >"$BB_DIR/xyz/s"
+
+	local deps
+	deps="$(get_task_deps "xyz" "abc")"
+	[[ "$deps" == "" ]]
+}
+
+@test "get_task_deps returns empty for non-existent subtask" {
+	source_libs
+
+	mkdir -p "$BB_DIR/xyz"
+	echo "abc - 0 " >"$BB_DIR/xyz/s"
+
+	local deps
+	deps="$(get_task_deps "xyz" "zzz")"
+	[[ "$deps" == "" ]]
+}
+
+# ============ validate_plan_format with new format ============
+
+@test "validate_plan_format passes on new deps format" {
+	source_libs
+
+	local plan
+	plan="zab overview: Brief summary, 50 words, deps:
+zcd details: Key information, 100 words, deps: zab
+zef conclusion: Summary, 50 words, deps: zcd"
+
+	run validate_plan_format "$plan"
+	[ "$status" -eq 0 ]
+}
+
+@test "validate_plan_format passes on mixed deps (some empty, some with deps)" {
+	source_libs
+
+	local plan
+	plan="zab planning: Gather info, 50 words, deps:
+zcd research: Analyze data, 100 words, deps: zab
+zef write: Draft document, 150 words, deps: zcd
+zij review: Final check, 50 words, deps: zef"
+
+	run validate_plan_format "$plan"
+	[ "$status" -eq 0 ]
+}
+
+@test "validate_plan_format passes on plan with multi-part deps" {
+	source_libs
+
+	local plan
+	plan="zab gather: Collect information, 50 words, deps:
+zcd analyze: Process data, 100 words, deps: zab
+zef write: Create draft, 150 words, deps: zab,zcd
+zij review: Check quality, 50 words, deps: zef"
+
+	run validate_plan_format "$plan"
+	[ "$status" -eq 0 ]
+}
+
+# ============ fill_missing_word_counts ensures deps: ============
+
+@test "fill_missing_word_counts adds deps: suffix when missing" {
+	source_libs
+
+	local result
+	result="$(fill_missing_word_counts "zab intro: Brief overview, 100 words")"
+	[[ "$result" == *"deps:"* ]]
+}
+
+@test "fill_missing_word_counts preserves existing deps field" {
+	source_libs
+
+	local result
+	result="$(fill_missing_word_counts "zab intro: Brief overview, 100 words, deps: zcd")"
+	[[ "$result" == *"deps: zcd"* ]]
+}
+
+# ============ MNTO_PLANNER_MODEL tests ============
+
+setup() {
+	export MNTO="${BATS_TEST_DIRNAME}/.."
+	export TEST_BB_DIR="$BATS_TMPDIR/mnto-planner-$BATS_TEST_NUMBER"
+	export BB_DIR="$TEST_BB_DIR/.bb"
+	mkdir -p "$BB_DIR"
+}
+
+teardown() {
+	rm -rf "$TEST_BB_DIR"
+}
+
+source_libs() {
+	source "$MNTO/lib/blackboard.bash"
+	source "$MNTO/lib/backend.bash"
+	source "$MNTO/lib/planner.bash"
+}
+
+# Redefine infer_with_backend after sourcing to mock it
+mock_infer_with_backend() {
+	unset -f infer_with_backend || true
+	eval "infer_with_backend() {
+		local backend=\"\$1\" role=\"\$2\" system=\"\$3\" context=\"\$4\"
+		echo \"zab intro: First section, 50 words, deps:
+zcd body: Second section, 100 words, deps: zab
+zef conclusion: Third section, 50 words, deps: zcd\"
+	}"
+}
+
+mock_infer() {
+	unset -f infer || true
+	eval "infer() {
+		local role=\"\$1\" system=\"\$2\" context=\"\$3\"
+		[[ \"\$role\" == \"planner\" ]]
+		echo \"zab intro: First section, 50 words, deps:
+zcd body: Second section, 100 words, deps: zab
+zef conclusion: Third section, 50 words, deps: zcd\"
+	}"
+}
+
+@test "MNTO_PLANNER_MODEL set uses that model for planning" {
+	setup
+	source_libs
+	mock_infer_with_backend
+	export MNTO_PLANNER_MODEL="openai:http://localhost:8080/v1:gpt-4"
+
+	local result
+	result="$(generate_plan "Test goal" 2>/dev/null || true)"
+	[[ "$result" == *"zab intro"* ]]
+}
+
+@test "MNTO_PLANNER_MODEL unset falls back to default inference" {
+	setup
+	source_libs
+	mock_infer
+	unset MNTO_PLANNER_MODEL || true
+
+	local result
+	result="$(generate_plan "Test goal" 2>/dev/null || true)"
+	[[ "$result" == *"zab intro"* ]]
+}
+
+# ============ SYS_PLAN output format verification ============
+
+@test "SYS_PLAN contains deps: format in examples" {
+	source_libs
+
+	# Verify the SYS_PLAN prompt contains the new format
+	[[ "$SYS_PLAN" == *"deps:"* ]]
+	[[ "$SYS_PLAN" == *"deps: zab"* ]]
+}
+
+@test "SYS_RESTRUCTURE contains deps: format in examples" {
+	source_libs
+
+	[[ "$SYS_RESTRUCTURE" == *"deps:"* ]]
+}
+
+@test "SYS_PLAN_MINIMAL contains deps: format in examples" {
+	source_libs
+
+	[[ "$SYS_PLAN_MINIMAL" == *"deps:"* ]]
+}
+
+@test "PLAN_TEMPLATE_GENERIC contains deps: format" {
+	source_libs
+
+	[[ "$PLAN_TEMPLATE_GENERIC" == *"deps:"* ]]
+	[[ "$PLAN_TEMPLATE_GENERIC" == *"deps: zab"* ]]
+	[[ "$PLAN_TEMPLATE_GENERIC" == *"deps: zcd"* ]]
+}


### PR DESCRIPTION
## Summary

Redesigns the planner from word-count text fragmentation to dependency-aware workflow steps — the first step of the mnto pivot from 'text fragmenter' to 'workflow orchestrator'.

### Changes
- **New plan format**: id label: description, N words, deps: id1,id2 with explicit dependency field
- **MNTO_PLANNER_MODEL**: Dedicated env var for planner model (defaults to MNTO_MODEL)
- **4-field status file**: Adds deps column to .mnto/bb/tid/s for DAG traversal in Issue #76
- **get_task_deps()**: New helper to retrieve subtask dependencies
- **Multi-sample planning**: Up to 3 attempts + 3-pass fallback chain + fixed template
- **Role-based temperature**: MNTO_TEMP_STRUCTURED/MNTO_TEMP_CREATIVE for inference quality
- **Robustness**: Short-draft early-exit, prev_output truncation

### Quality Gates
- 41/41 bats tests passing
- shellcheck: 0 errors
- bash -n: passing

Fixes #75