### PR TITLE
feat(#78): auto-routing + refactor(#81): deduplicate infer_with_backend dispatch

### DIFF
--- a/lib/backend.bash
+++ b/lib/backend.bash
@@ -13,6 +13,34 @@ set -euo pipefail
 [[ -n "${_BACKEND_SOURCED:-}" ]] && return 0
 declare -r _BACKEND_SOURCED=1
 
+# Usage: _infer_dispatch <backend_spec> <system> <context> <outfile>
+# Internal: dispatch to backend implementation
+# Returns: 0 on success, 1 on failure, 3 on guardrail, 4 on overflow
+_infer_dispatch() {
+	local backend="$1"
+	local system="$2"
+	local context="$3"
+	local outfile="${4:-}"
+
+	local backend_type="${backend%%:*}"
+	case "$backend_type" in
+	apfel)
+		_infer_apfel "$system" "$context" "$outfile"
+		;;
+	openai)
+		_valid_openai_spec "$backend" || {
+			echo "ERROR: OpenAI backend requires spec format openai:URL:MODEL" >&2
+			return 1
+		}
+		_infer_openai "$backend" "$system" "$context" "$outfile"
+		;;
+	*)
+		echo "ERROR: Invalid backend specification: $backend (expected openai:URL:MODEL)" >&2
+		return 1
+		;;
+	esac
+}
+
 # Usage: infer <role> <system_prompt> <context> [output_file]
 # Role-based inference dispatcher
 # role: planner|proposer|verifier|stitcher
@@ -45,33 +73,7 @@ infer() {
 	local backend
 	backend="$(_resolve_backend "$role")"
 
-	# Unified validation and dispatch:
-	# - Extract backend type (before first colon)
-	# - Validate according to type
-	# - Dispatch to appropriate function
-	local backend_type="${backend%%:*}"
-	case "$backend_type" in
-	apfel)
-		# apfel backend accepts both "apfel" and "apfel:spec"
-		# (apfel has no temperature control — env var is ignored)
-		_infer_apfel "$system" "$context" "$outfile"
-		;;
-	openai)
-		# OpenAI backend requires full spec: openai:URL:MODEL (two colons after prefix)
-		if _valid_openai_spec "$backend"; then
-			_infer_openai "$backend" "$system" "$context" "$outfile"
-		else
-			# Invalid: missing URL and/or model segments
-			echo "ERROR: OpenAI backend requires spec format openai:URL:MODEL" >&2
-			return 1
-		fi
-		;;
-	*)
-		# Unknown backend type
-		echo "ERROR: Invalid backend specification: $backend (expected openai:URL:MODEL)" >&2
-		return 1
-		;;
-	esac
+	_infer_dispatch "$backend" "$system" "$context" "$outfile"
 }
 
 # Usage: _valid_openai_spec <backend_spec>
@@ -162,4 +164,26 @@ _infer_apfel() {
 		apfel -q -s "$system" "$context" 2>/dev/null
 	fi
 	# Exit codes pass through naturally: 3=guardrail, 4=overflow
+}
+
+# Usage: infer_with_backend <backend> <role> <system> <context> [outfile]
+# Invoke infer with explicit backend instead of role-based dispatch
+# Usage: out="$(infer_with_backend "$backend" "$role" "$system" "$context")"
+infer_with_backend() {
+	local backend="$1"
+	local role="$2"
+	local system="$3"
+	local context="$4"
+	local outfile="${5:-}"
+
+	# Mirror temperature injection from backend.bash:infer()
+	local temperature
+	case "$role" in
+	planner | verifier) temperature="${MNTO_TEMP_STRUCTURED:-0.2}" ;;
+	proposer | stitcher) temperature="${MNTO_TEMP_CREATIVE:-0.7}" ;;
+	*) temperature="0.7" ;;
+	esac
+	export MNTO_TEMPERATURE="$temperature"
+
+	_infer_dispatch "$backend" "$system" "$context" "$outfile"
 }

--- a/lib/backend.bash
+++ b/lib/backend.bash
@@ -181,7 +181,10 @@ infer_with_backend() {
 	case "$role" in
 	planner | verifier) temperature="${MNTO_TEMP_STRUCTURED:-0.2}" ;;
 	proposer | stitcher) temperature="${MNTO_TEMP_CREATIVE:-0.7}" ;;
-	*) temperature="0.7" ;;
+	*)
+		echo "WARNING: unknown role '${role}', defaulting temperature to 0.7" >&2
+		temperature="0.7"
+		;;
 	esac
 	export MNTO_TEMPERATURE="$temperature"
 

--- a/lib/direct.bash
+++ b/lib/direct.bash
@@ -29,6 +29,29 @@ is_direct_task() {
 	return 1
 }
 
+# Determine if goal should use workflow executor.
+# Returns: 0 (use workflow) or 1 (use direct/single-shot)
+# Usage: should_use_workflow <goal>
+should_use_workflow() {
+	local goal="$1"
+
+	# Explicit force flags
+	[[ "${MNTO_FORCE_WORKFLOW:-}" == "true" ]] && return 0
+	[[ "${MNTO_FORCE_DIRECT:-}" == "true" ]] && return 1
+
+	# Token size heuristic (chars / 4 ≈ tokens)
+	local threshold="${MNTO_WORKFLOW_THRESHOLD:-120000}"
+	local estimated_chars="${#goal}"
+	((estimated_chars > threshold)) && return 0
+
+	# Sequential intent signals
+	echo "$goal" | grep -qiE \
+		'(then|after|followed by|depends on|step [0-9]|first.*then|review.*and)' &&
+		return 0
+
+	return 1
+}
+
 # Run a task in direct mode: single inference call, no plan/verify/stitch.
 # Usage: run_direct <tid>
 # Reads: .mnto/bb/{tid}/g (goal)

--- a/lib/direct.bash
+++ b/lib/direct.bash
@@ -10,25 +10,6 @@ if [[ "${_BLACKBOARD_SOURCED:-}" != "1" ]] || [[ "${_BACKEND_SOURCED:-}" != "1" 
 	return 1 2>/dev/null || exit 1
 fi
 
-# Threshold for direct mode: goals shorter than this bypass the harness.
-# Configurable via MNTO_DIRECT_THRESHOLD (default: 300 chars).
-readonly DIRECT_THRESHOLD="${MNTO_DIRECT_THRESHOLD:-300}"
-
-# Check if a goal is simple enough for direct single-shot inference.
-# Usage: is_direct_task "$goal"
-# Returns: 0 if direct mode should be used, 1 if harness should be used.
-is_direct_task() {
-	local goal="$1"
-	local goal_len=${#goal}
-
-	# Short goals don't benefit from decomposition
-	if ((goal_len <= DIRECT_THRESHOLD)); then
-		return 0
-	fi
-
-	return 1
-}
-
 # Determine if goal should use workflow executor.
 # Returns: 0 (use workflow) or 1 (use direct/single-shot)
 # Usage: should_use_workflow <goal>
@@ -41,13 +22,16 @@ should_use_workflow() {
 
 	# Token size heuristic (chars / 4 ≈ tokens)
 	local threshold="${MNTO_WORKFLOW_THRESHOLD:-120000}"
+	# Validate threshold is numeric; fall back to default if not
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=120000
 	local estimated_chars="${#goal}"
 	((estimated_chars > threshold)) && return 0
 
 	# Sequential intent signals
-	echo "$goal" | grep -qiE \
-		'(then|after|followed by|depends on|step [0-9]|first.*then|review.*and)' &&
+	if echo "$goal" | grep -qiE \
+		'(then|after|followed by|depends on|step [0-9]|first.*then|review.*and)'; then
 		return 0
+	fi
 
 	return 1
 }

--- a/lib/planner.bash
+++ b/lib/planner.bash
@@ -113,45 +113,6 @@ _plan_infer() {
 	echo "$out"
 }
 
-# Invoke infer with explicit backend instead of role-based dispatch
-# Usage: out="$(infer_with_backend "$backend" "$role" "$system" "$context")"
-infer_with_backend() {
-	local backend="$1"
-	local role="$2"
-	local system="$3"
-	local context="$4"
-	local outfile="${5:-}"
-
-	# Mirror temperature injection from backend.bash:infer()
-	local temperature
-	case "$role" in
-	planner | verifier) temperature="${MNTO_TEMP_STRUCTURED:-0.2}" ;;
-	proposer | stitcher) temperature="${MNTO_TEMP_CREATIVE:-0.7}" ;;
-	*) temperature="0.7" ;;
-	esac
-	export MNTO_TEMPERATURE="$temperature"
-
-	# Unified validation and dispatch via backend type
-	local backend_type="${backend%%:*}"
-	case "$backend_type" in
-	apfel)
-		_infer_apfel "$system" "$context" "$outfile"
-		;;
-	openai)
-		if _valid_openai_spec "$backend"; then
-			_infer_openai "$backend" "$system" "$context" "$outfile"
-		else
-			echo "ERROR: OpenAI backend requires spec format openai:URL:MODEL" >&2
-			return 1
-		fi
-		;;
-	*)
-		echo "ERROR: Invalid backend specification: $backend" >&2
-		return 1
-		;;
-	esac
-}
-
 # Generate plan from goal using infer planner
 # Strategy: multi-sample with same prompt (up to 3), then restructure
 # fallback, then minimal prompt, then fixed template.

--- a/mnto
+++ b/mnto
@@ -78,10 +78,17 @@ Commands:
 Options:
   -h, --help            Show this help
   --dry-run             Show actions without executing (also --clean, --prune)
+  --workflow            Force workflow executor (skip direct mode)
+  --direct              Force direct mode (bypass workflow harness)
   --plan-model {url}    Use external model (legacy alias for --proposer)
   --proposer {spec}     Model spec for proposer/planner/stitcher (apfel or openai:URL:MODEL)
   --verifier {spec}     Model spec for verifier (apfel or openai:URL:MODEL)
   --vipune              Enable vipune semantic search integration
+
+Routing:
+  --workflow and --direct override automatic routing.
+  Set MNTO_WORKFLOW_THRESHOLD (default: 120000 chars ≈ 30K tokens) to tune the
+  auto-routing threshold. MNTO_FORCE_WORKFLOW and MNTO_FORCE_DIRECT also work.
 
 Model selection precedence:
   --proposer/--verifier > MNTO_PROPOSER/MNTO_VERIFIER > MNTO_MODEL > apfel
@@ -146,10 +153,10 @@ create_task() {
 	# Save goal
 	echo "$goal" >"$bb_dir/g"
 
-	# Smart routing: short/simple goals bypass the harness entirely.
-	# Research shows single-agent systems outperform multi-agent on
-	# sequential reasoning with matched token budgets.
-	if is_direct_task "$goal"; then
+	# Routing: use direct mode for simple goals, workflow for complex ones.
+	# Auto-routing uses token heuristic, sequential intent signals, and
+	# explicit --workflow/--direct flags override the default behavior.
+	if ! should_use_workflow "$goal"; then
 		if run_direct "$tid"; then
 			echo "Created task: $tid"
 			return 0
@@ -259,6 +266,15 @@ parse_options() {
 			;;
 		--dry-run)
 			DRY_RUN="true"
+			shift
+			;;
+		--workflow)
+			# Note: --workflow takes precedence over --direct if both are specified
+			export MNTO_FORCE_WORKFLOW="true"
+			shift
+			;;
+		--direct)
+			export MNTO_FORCE_DIRECT="true"
 			shift
 			;;
 		--plan-model)

--- a/test/backend.bats
+++ b/test/backend.bats
@@ -214,12 +214,12 @@ mock_apfel_overflow() {
 # Test _infer_apfel with system prompts and context
 @test "_infer_apfel calls apfel with correct arguments without output file" {
 	apfel() {
-		# Should receive exactly 2 args: system and context
-		if [[ $# -eq 2 ]]; then
+		# Receives 4 args: -q, -s, system, context
+		if [[ $# -eq 4 && "$3" == "system prompt" && "$4" == "user context" ]]; then
 			echo "mocked response"
 			return 0
 		else
-			echo "ERROR: wrong arg count $#, expected 2" >&2
+			echo "ERROR: wrong arg count $#, expected 4" >&2
 			return 1
 		fi
 	}
@@ -234,7 +234,7 @@ mock_apfel_overflow() {
 @test "_infer_apfel handles context starting with dash" {
 	apfel() {
 		# Capture arguments to verify safety - context should have leading newline
-		if [[ "$2" == $'\n'* ]]; then
+		if [[ "$4" == $'\n'* ]]; then
 			# Context was properly escaped
 			echo "safe response"
 			return 0
@@ -271,12 +271,12 @@ mock_apfel_overflow() {
 # Test _infer_apfel with output file argument
 @test "_infer_apfel writes to output file when provided" {
 	apfel() {
-		# Uses redirection, receives only 2 positional args: system and context
-		if [[ $# -eq 2 ]]; then
+		# Uses redirection, receives 4 positional args: -q -s system context
+		if [[ $# -eq 4 ]]; then
 			echo "response written to file"
 			return 0
 		else
-			echo "wrong - received $# args, expected 2"
+			echo "wrong - received $# args, expected 4"
 			return 1
 		fi
 	}
@@ -296,12 +296,12 @@ mock_apfel_overflow() {
 
 @test "_infer_apfel uses stdout when no output file provided" {
 	apfel() {
-		# No output file: receives 2 positional args
-		if [[ $# -eq 2 ]]; then
+		# No output file: receives 4 positional args: -q -s system context
+		if [[ $# -eq 4 ]]; then
 			echo "stdout response"
 			return 0
 		else
-			echo "wrong - received $# args, expected 2"
+			echo "wrong - received $# args, expected 4"
 			return 1
 		fi
 	}

--- a/test/e2e/e2e.bats
+++ b/test/e2e/e2e.bats
@@ -64,20 +64,20 @@ source_harness() {
 # ============================================================================
 # Scenario 01: Single-shot routing
 # Goal: Short goal that should bypass harness and use direct mode
-# Signal: is_direct_task returns 0 for short goals
+# Signal: should_use_workflow returns 1 for short goals (direct mode)
 # ============================================================================
 
 @test "scenario_01_single_shot_routing" {
 	source_harness
 
-	# Create a short goal (under DIRECT_THRESHOLD of 300 chars)
+	# Create a short goal (under workflow threshold)
 	local tid="t01"
 	mkdir -p "$BB_DIR/$tid"
 	echo "Summarize: The quick brown fox jumps over the lazy dog." >"$BB_DIR/$tid/g"
 
-	# is_direct_task should return 0 for short goals
-	is_direct_task "$(cat "$BB_DIR/$tid/g")"
-	[ $? -eq 0 ]
+	# should_use_workflow should return 1 for short goals
+	run should_use_workflow "$(cat "$BB_DIR/$tid/g")"
+	[[ $status -eq 1 ]]
 
 	# Verify no status file was created (direct mode path)
 	# In direct mode, parse_plan is not called, so no status file

--- a/test/routing.bats
+++ b/test/routing.bats
@@ -1,0 +1,213 @@
+#!/usr/bin/env bats
+# Routing tests for auto-routing (issue #78) and dispatch deduplication (issue #81)
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+setup() {
+	export MNTO="${BATS_TEST_DIRNAME}/.."
+	export TEST_BB_DIR="$BATS_TMPDIR/mnto-routing-$BATS_TEST_NUMBER"
+	export BB_DIR="$TEST_BB_DIR/.bb"
+	mkdir -p "$BB_DIR"
+
+	# openai.bash must be sourced before backend.bash (order matters)
+	source "$MNTO/lib/openai.bash"
+	source "$MNTO/lib/blackboard.bash"
+	source "$MNTO/lib/backend.bash"
+	source "$MNTO/lib/planner.bash"
+	source "$MNTO/lib/direct.bash"
+}
+
+teardown() {
+	rm -rf "$TEST_BB_DIR"
+}
+
+# ============================================================
+# Issue #81: _infer_dispatch and infer_with_backend tests
+# ============================================================
+
+# For these tests we need to mock at the function level since
+# _infer_apfel and _infer_openai are called internally by _infer_dispatch.
+
+@test "_infer_dispatch: calls _infer_apfel for apfel backend" {
+	# Mock _infer_apfel - receives: system context outfile (no backend arg)
+	_infer_apfel() {
+		local system="$1" context="$2" outfile="$3"
+		if [[ -n "$outfile" ]]; then
+			echo "apfel-dispatched" > "$outfile"
+		else
+			echo "apfel-dispatched"
+		fi
+	}
+	export -f _infer_apfel
+
+	local outfile="$TEST_BB_DIR/out.txt"
+	_infer_dispatch "apfel" "system prompt" "context" "$outfile"
+
+	[[ -f "$outfile" ]]
+	grep -q "apfel-dispatched" "$outfile"
+}
+
+@test "_infer_dispatch: calls _infer_openai for openai backend" {
+	# Mock _infer_openai - receives: backend system context outfile
+	_infer_openai() {
+		local backend="$1" system="$2" context="$3" outfile="$4"
+		if [[ -n "$outfile" ]]; then
+			echo "openai-dispatched" > "$outfile"
+		else
+			echo "openai-dispatched"
+		fi
+	}
+	export -f _infer_openai
+
+	local outfile="$TEST_BB_DIR/out.txt"
+	_infer_dispatch "openai:http://localhost:8080/v1:gpt-4" "system prompt" "context" "$outfile"
+
+	[[ -f "$outfile" ]]
+	grep -q "openai-dispatched" "$outfile"
+}
+
+@test "_infer_dispatch: errors on unknown backend type" {
+	run _infer_dispatch "unknown:type" "system" "context" ""
+	[[ $status -ne 0 ]]
+	[[ "$output" == *"ERROR: Invalid backend specification"* ]]
+}
+
+@test "infer_with_backend: delegates to _infer_dispatch for apfel" {
+	# Mock _infer_apfel - receives: system context outfile (no backend arg)
+	_infer_apfel() {
+		local system="$1" context="$2" outfile="$3"
+		if [[ -n "$outfile" ]]; then
+			echo "apfel-dispatched" > "$outfile"
+		else
+			echo "apfel-dispatched"
+		fi
+	}
+	export -f _infer_apfel
+
+	local out
+	out="$(infer_with_backend "apfel" "proposer" "system" "context" 2>/dev/null)" || true
+
+	[[ "$out" == "apfel-dispatched" ]]
+}
+
+# ============================================================
+# Issue #78: Auto-routing tests
+# ============================================================
+
+@test "should_use_workflow: function exists" {
+	type should_use_workflow >/dev/null 2>&1
+}
+
+@test "should_use_workflow: MNTO_FORCE_WORKFLOW=true forces workflow" {
+	MNTO_FORCE_WORKFLOW="true"
+	run should_use_workflow "Hello world"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: MNTO_FORCE_DIRECT=true forces direct" {
+	MNTO_FORCE_DIRECT="true"
+	run should_use_workflow "Hello world"
+	[[ $status -eq 1 ]]
+}
+
+@test "should_use_workflow: large goal routes to workflow" {
+	local large_goal
+	large_goal="$(printf 'x%.0s' {1..130000})"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$large_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: small goal without intent routes to direct" {
+	local small_goal="This is a simple task."
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$small_goal"
+	[[ $status -eq 1 ]]
+}
+
+@test "should_use_workflow: goal with 'then' routes to workflow" {
+	local sequential_goal="First do the introduction, then write the body, then conclude."
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$sequential_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: goal with 'after' routes to workflow" {
+	local after_goal="Gather materials after securing the permit"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$after_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: goal with 'depends on' routes to workflow" {
+	local dep_goal="Task B depends on Task A completing first"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$dep_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: goal with 'step 1' routes to workflow" {
+	local step_goal="Step 1: gather materials, Step 2: build foundation"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$step_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: goal with 'first...then' routes to workflow" {
+	local first_then_goal="First write the introduction, then elaborate the main points"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$first_then_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: goal with 'review and' routes to workflow" {
+	local review_goal="Write the content, review and revise the document"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$review_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: MNTO_FORCE_WORKFLOW overrides threshold" {
+	local small_goal="Short task"
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	MNTO_FORCE_WORKFLOW="true"
+
+	run should_use_workflow "$small_goal"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: MNTO_FORCE_DIRECT overrides threshold" {
+	local large_goal
+	large_goal="$(printf 'x%.0s' {1..200000})"
+	MNTO_WORKFLOW_THRESHOLD="100"
+	MNTO_FORCE_DIRECT="true"
+
+	run should_use_workflow "$large_goal"
+	[[ $status -eq 1 ]]
+}
+
+@test "should_use_workflow: 100 char threshold with 200 char goal routes to workflow" {
+	local goal200
+	goal200="$(printf 'x%.0s' {1..200})"
+	MNTO_WORKFLOW_THRESHOLD="100"
+
+	run should_use_workflow "$goal200"
+	[[ $status -eq 0 ]]
+}
+
+@test "should_use_workflow: simple sentence without signals routes to direct" {
+	local simple_goal="Write a haiku about autumn leaves"
+
+	MNTO_WORKFLOW_THRESHOLD="120000"
+	run should_use_workflow "$simple_goal"
+	[[ $status -eq 1 ]]
+}


### PR DESCRIPTION
### Summary

- **#78**: Intelligent auto-routing — dispatches to single-shot or workflow executor based on input size, explicit flags, and sequential intent signals
- **#81**: Deduplicate `infer_with_backend` dispatch — extract `_infer_dispatch()` in `backend.bash`, move `infer_with_backend()` out of `planner.bash`

### Changes

**Auto-routing (#78)**
- New `should_use_workflow()` in `lib/direct.bash` — checks `MNTO_FORCE_WORKFLOW`, `MNTO_FORCE_DIRECT`, char threshold, sequential intent signals
- `--workflow` / `--direct` CLI flags added to `mnto`
- `MNTO_WORKFLOW_THRESHOLD` env var (default: 120000 chars ≈ 30K tokens, from benchmark #77)
- 19 new routing tests in `test/routing.bats`

**Deduplication (#81)**
- New `_infer_dispatch()` private function in `lib/backend.bash`
- `infer()` and `infer_with_backend()` both delegate to `_infer_dispatch`
- `infer_with_backend()` moved from `lib/planner.bash` to `lib/backend.bash`

### Routing behaviour
```bash
./mnto 'short goal'                    # auto: single-shot (small input)
./mnto 'review this 80K diff: ...'     # auto: workflow (large input)
./mnto --workflow 'any goal'           # force workflow
./mnto --direct 'any goal'             # force single-shot
MNTO_WORKFLOW_THRESHOLD=5000 ./mnto    # custom threshold
```

Fixes #78
Fixes #81